### PR TITLE
Make link from URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A DAW for Microsoft Excel
 I think this is how you're supposed to do it?
 
 This is the github page for xlStudio, with the modules separated.
-You can watch the tutorial for xlStudio here: youtu.be/RFdCM2kHL64
+You can watch the tutorial for xlStudio here: https://youtu.be/RFdCM2kHL64


### PR DESCRIPTION
Added the protocol in front of the URL to allow GitHub to automatically convert it to a clickable link.  
See issue #2 